### PR TITLE
Add reject function

### DIFF
--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -21,6 +21,9 @@ let sleep (ms: int): JS.Promise<unit> = jsNative
 [<Emit("Promise.resolve($0)")>]
 let lift<'T> (a: 'T): JS.Promise<'T> = jsNative
 
+/// Creates promise (in rejected state) with supplied reason.
+let reject<'T> reason : JS.Promise<'T> = JS.Promise.reject<'T> reason
+
 [<Emit("$1.then($0)")>]
 let bind (a: 'T->JS.Promise<'R>) (pr: JS.Promise<'T>): JS.Promise<'R> = jsNative
 


### PR DESCRIPTION
This function allows:

```fs
    let private requestCanFail<'a, 'b> (fsacAction : string) id requestId (obj : 'a) =
         requestRaw fsacAction id requestId obj
         |> Promise.bind(fun (r : FSACResponse<'b>) ->
             match r with
             | FSACResponse.Error (msg, err) ->
                log.Error (prettyPrintError fsacAction msg err)
                Promise.reject (msg, err) // This line works with the patch
             | FSACResponse.Kind (t, res) ->
                Promise.lift res
             | FSACResponse.Info _
             | FSACResponse.Invalid ->
                Promise.lift (null |> unbox)
          )
```

Without the path, we have this error:

```
A member or object constructor 'reject' taking 2 arguments is not accessible from this code location. All accessible versions of method 'reject' take 1 arguments.
```

Also, the proposed helpers returns `JS.Promise<'T>` instead of `JS.Promise<unit>` so it can be applied in any chain.