### PR TITLE
Cleanup before release 3.0

### DIFF
--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -35,11 +35,11 @@ let tap (fn: 'T -> unit) (a: JS.Promise<'T>): JS.Promise<'T> =
     a |> map (fun x -> fn x; x)
 
 [<Emit("$1.catch($0)")>]
-/// This version of `catch` expects a function returning just 'T, as opposed to `Promise<'T>`. If you need to return `Promise<'T>`, use `catchBind`.
+/// This version of `catch` expects a function returning just `'T`, as opposed to `Promise<'T>`. If you need to return `Promise<'T>`, use `catchBind`.
 let catch (fail: exn -> 'T) (pr: JS.Promise<'T>): JS.Promise<'T> = jsNative
 
 [<Emit("$1.catch($0)")>]
-/// This version of `catch` expects a function returning Promise<'T> as opposed to just 'T. If you need to return just 'T, use `catch`.
+/// This version of `catch` expects a function returning `Promise<'T>` as opposed to just `'T`. If you need to return just 'T, use `catch`.
 let catchBind (fail: exn -> JS.Promise<'T>) (pr: JS.Promise<'T>): JS.Promise<'T> = jsNative
 
 [<Emit("void ($1.catch($0))")>]

--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -8,11 +8,9 @@ open System
 open Fable.Core
 open Fable.Core.JsInterop
 
-let inline private (!!) (x:obj): 'T = unbox x
-
 [<Emit("new Promise($0)")>]
 /// The promise function receives two other function parameters: success and fail
-let create (f: ('T->unit)->(Exception->unit)->unit): JS.Promise<'T> = jsNative
+let create (f: ('T -> unit) -> (exn -> unit) -> unit): JS.Promise<'T> = jsNative
 
 [<Emit("new Promise(resolve => setTimeout(resolve, $0))")>]
 let sleep (ms: int): JS.Promise<unit> = jsNative
@@ -20,45 +18,50 @@ let sleep (ms: int): JS.Promise<unit> = jsNative
 [<Emit("Promise.resolve($0)")>]
 let lift<'T> (a: 'T): JS.Promise<'T> = jsNative
 
+[<Emit("Promise.reject($0)")>]
 /// Creates promise (in rejected state) with supplied reason.
-let reject<'T> reason : JS.Promise<'T> = JS.Constructors.Promise.reject<'T> reason
+let reject<'T> (reason: exn) : JS.Promise<'T> = jsNative
 
 [<Emit("$1.then($0)")>]
-let bind (a: 'T->JS.Promise<'R>) (pr: JS.Promise<'T>): JS.Promise<'R> = jsNative
+let bind (a: 'T1 -> JS.Promise<'T2>) (pr: JS.Promise<'T1>): JS.Promise<'T2> = jsNative
 
 [<Emit("$1.then($0)")>]
-let map (a: 'T->'R) (pr: JS.Promise<'T>): JS.Promise<'R> = jsNative
+let map (a: 'T1 -> 'T2) (pr: JS.Promise<'T>): JS.Promise<'T2> = jsNative
 
-[<Emit("$1.then($0)")>]
-let iter (a: 'T->unit) (pr: JS.Promise<'T>): unit = jsNative
+[<Emit("void ($1.then($0))")>]
+let iter (a: 'T -> unit) (pr: JS.Promise<'T>): unit = jsNative
 
-[<Emit("$1.catch($0)")>]
-/// This version of `catch` fakes a function returning just 'T, as opposed to `Promise<'T>`. If you need to return `Promise<'T>`, use `catchBind`.
-let catch (fail: Exception->'T) (pr: JS.Promise<'T>): JS.Promise<'T> = jsNative
-
-[<Emit("$1.catch($0)")>]
-/// This is a version of `catch` that fakes a function returning Promise<'T> as opposed to just 'T. If you need to return just 'T, use `catch`.
-let catchBind (fail: Exception->JS.Promise<'T>) (pr: JS.Promise<'T>): JS.Promise<'T> = jsNative
+let tap (fn: 'T -> unit) (a: JS.Promise<'T>): JS.Promise<'T> =
+    a |> map (fun x -> fn x; x)
 
 [<Emit("$1.catch($0)")>]
+/// This version of `catch` expects a function returning just 'T, as opposed to `Promise<'T>`. If you need to return `Promise<'T>`, use `catchBind`.
+let catch (fail: exn -> 'T) (pr: JS.Promise<'T>): JS.Promise<'T> = jsNative
+
+[<Emit("$1.catch($0)")>]
+/// This version of `catch` expects a function returning Promise<'T> as opposed to just 'T. If you need to return just 'T, use `catch`.
+let catchBind (fail: exn -> JS.Promise<'T>) (pr: JS.Promise<'T>): JS.Promise<'T> = jsNative
+
+[<Emit("void ($1.catch($0))")>]
 /// Used to catch errors at the end of a promise chain.
-let catchEnd (fail: Exception->unit) (pr: JS.Promise<'T>): unit = jsNative
+let catchEnd (fail: exn -> unit) (pr: JS.Promise<'T>): unit = jsNative
 
 [<Emit("$2.then($0).catch($1)")>]
-/// A combination of `map/bind` and `catch/catchBind`, this function applies the `success` continuation when the input promise resolves successfully, or `fail` continuation when the input promise fails. Both continuations may return either naked value `'R` or another promise `Promise<'R>`. Use the erased-cast operator `!^` to cast values when returning, for example:
-/// ```
-/// somePromise |> Promise.either (fun x -> !^(string x)) (fun err -> ^!(Promise.lift err.Message))
-/// ```
-let either (success: 'T->U2<'R, JS.Promise<'R>>) (fail: 'E->U2<'R, JS.Promise<'R>>) (pr: JS.Promise<'T>): JS.Promise<'R> = jsNative
+/// A combination of `map` and `catch`, this function applies the `success` continuation when the input promise resolves successfully, or `fail` continuation when the input promise fails.
+let either (success: 'T1 -> 'T2) (fail: exn -> 'T2) (pr: JS.Promise<'T1>): JS.Promise<'T2> = jsNative
 
 [<Emit("$2.then($0).catch($1)")>]
-let eitherEnd (success: 'T->unit) (fail: 'E->unit) (pr: JS.Promise<'T>): unit = jsNative
+/// A combination of `bind` and `catchBind`, this function applies the `success` continuation when the input promise resolves successfully, or `fail` continuation when the input promise fails.
+let eitherBind (success: 'T1 -> JS.Promise<'T2>) (fail: exn -> JS.Promise<'T2>) (pr: JS.Promise<'T1>): JS.Promise<'T2> = jsNative
 
-[<Emit("$0")>]
+[<Emit("void ($2.then($0).catch($1))")>]
+let eitherEnd (success: 'T -> unit) (fail: exn -> unit) (pr: JS.Promise<'T>): unit = jsNative
+
+[<Emit("void $0")>]
 let start (pr: JS.Promise<'T>): unit = jsNative
 
 [<Emit("$1.catch($0)")>]
-let tryStart (fail: Exception->unit) (pr: JS.Promise<'T>): unit = jsNative
+let tryStart (fail: exn -> unit) (pr: JS.Promise<'T>): unit = jsNative
 
 [<Emit("Promise.all($0)")>]
 let Parallel (pr: seq<JS.Promise<'T>>): JS.Promise<'T[]> = jsNative
@@ -66,107 +69,106 @@ let Parallel (pr: seq<JS.Promise<'T>>): JS.Promise<'T[]> = jsNative
 [<Emit("Promise.all($0)")>]
 let all (pr: seq<JS.Promise<'T>>): JS.Promise<'T[]> = jsNative
 
-let result (a: JS.Promise<'A>): JS.Promise<Result<'A, 'E>> =
-    either (U2.Case1 << Ok) (U2.Case1 << Error) a
+let result (a: JS.Promise<'T>): JS.Promise<Result<'T, exn>> =
+    either Ok Error a
 
-let mapResult (fn: 'A -> 'B) (a: JS.Promise<Result<'A, 'E>>): JS.Promise<Result<'B, 'E>> =
+let mapResult (fn: 'T1 -> 'T2) (a: JS.Promise<Result<'T1, 'E>>): JS.Promise<Result<'T2, 'E>> =
     a |> map (Result.map fn)
 
-let bindResult (fn: 'A -> JS.Promise<'B>) (a: JS.Promise<Result<'A, 'E>>): JS.Promise<Result<'B, 'E>> =
+let bindResult (fn: 'T1 -> JS.Promise<'T2>) (a: JS.Promise<Result<'T1, 'E>>): JS.Promise<Result<'T2, 'E>> =
     a |> bind (fun a ->
         match a with
         | Ok a ->
-            result (fn a)
+            fn a |> map Ok
         | Error e ->
             lift (Error e))
 
-let mapResultError (fn: 'B -> 'C) (a: JS.Promise<Result<'A,'B>>): JS.Promise<Result<'A,'C>> =
+let mapResultError (fn: 'E1 -> 'E2) (a: JS.Promise<Result<'T, 'E1>>): JS.Promise<Result<'T, 'E2>> =
     a |> map (Result.mapError fn)
-
-let tap (fn: 'A -> unit) (a: JS.Promise<'A>): JS.Promise<'A> =
-    a |> map (fun x -> fn x; x)
 
 type PromiseBuilder() =
     [<Emit("$1.then($2)")>]
-    member x.Bind(p: JS.Promise<'T>, f: 'T->JS.Promise<'R>): JS.Promise<'R> = jsNative
+    member _.Bind(p: JS.Promise<'T1>, f: 'T1 -> JS.Promise<'T2>): JS.Promise<'T2> = jsNative
 
     [<Emit("$1.then(() => $2)")>]
-    member x.Combine(p1: JS.Promise<unit>, p2: JS.Promise<'T>): JS.Promise<'T> = jsNative
+    member _.Combine(p1: JS.Promise<unit>, p2: JS.Promise<'T>): JS.Promise<'T> = jsNative
 
-    member x.For(seq: seq<'T>, body: 'T -> JS.Promise<unit>): JS.Promise<unit> =
+    member _.For(seq: seq<'T>, body: 'T -> JS.Promise<unit>): JS.Promise<unit> =
         // (lift (), seq)
         // ||> Seq.fold (fun p a ->
         //     bind (fun () -> body a) p)
         let mutable p = lift ()
         for a in seq do
-            p <- !!p?``then``(fun () -> body a)
+            p <- p |> bind (fun () -> body a)
         p
 
     [<Emit("$1.then($2)")>]
-    member x.For(p: JS.Promise<'T>, f: 'T->JS.Promise<'R>): JS.Promise<'R> = jsNative
+    member _.For(p: JS.Promise<'T1>, f: 'T1 -> JS.Promise<'T2>): JS.Promise<'T2> = jsNative
 
-    member x.While(guard, p): JS.Promise<unit> =
+    member this.While(guard: unit -> bool, p: JS.Promise<unit>): JS.Promise<unit> =
         if guard()
-        then bind (fun () -> x.While(guard, p)) p
+        then bind (fun () -> this.While(guard, p)) p
         else lift()
 
     [<Emit("Promise.resolve($1)")>]
-    member x.Return(a: 'T): JS.Promise<'T> = jsNative
+    member _.Return(a: 'T): JS.Promise<'T> = jsNative
 
     [<Emit("$1")>]
-    member x.ReturnFrom(p: JS.Promise<'T>): JS.Promise<'T> = jsNative
+    member _.ReturnFrom(p: JS.Promise<'T>): JS.Promise<'T> = jsNative
 
     [<Emit("Promise.resolve()")>]
-    member x.Zero(): JS.Promise<unit> = jsNative
+    member _.Zero(): JS.Promise<unit> = jsNative
 
-    member x.TryFinally(p: JS.Promise<'T>, compensation: unit->unit): JS.Promise<'T> =
-        either (fun (x: 'T) -> compensation(); U2.Case1 x) (fun er -> compensation(); raise !!er) p
+    member _.TryFinally(p: JS.Promise<'T>, compensation: unit -> unit): JS.Promise<'T> =
+        either (fun (x: 'T) -> compensation(); x) (fun er -> compensation(); raise er) p
 
     [<Emit("$1.catch($2)")>]
-    member x.TryWith(p: JS.Promise<'T>, catchHandler: Exception->JS.Promise<'T>): JS.Promise<'T> = jsNative
+    member _.TryWith(p: JS.Promise<'T>, catchHandler: exn -> JS.Promise<'T>): JS.Promise<'T> = jsNative
 
-    member x.Delay(generator: unit->JS.Promise<'T>): JS.Promise<'T> =
+    // Delay must generate a cold promise-like object that re-runs every time it's called,
+    // so we cannot use the JS Promise constructor which is stateful
+    member _.Delay(generator: unit -> JS.Promise<'T>): JS.Promise<'T> =
         !!createObj[
-            "then" ==> fun f1 f2 ->
-                try generator()?``then``(f1,f2)
+            "then" ==> fun onSuccess onError ->
+                try generator().``then``(onSuccess, onError)
                 with er ->
-                    if box f2 = null
-                    then !!JS.Constructors.Promise.reject(er)
+                    if isNull(box onError) then reject er
                     else
-                        try !!JS.Constructors.Promise.resolve(f2(er))
-                        with er -> !!JS.Constructors.Promise.reject(er)
-            "catch" ==> fun f ->
-                try generator()?catch(f)
+                        try onError er |> lift
+                        with er -> reject er
+            "catch" ==> fun onError ->
+                try generator().catch(onError)
                 with er ->
-                    try !!JS.Constructors.Promise.resolve(f(er))
-                    with er -> !!JS.Constructors.Promise.reject(er)
+                    try onError er |> lift
+                    with er -> reject er
         ]
 
-    member x.Run(p:JS.Promise<'T>): JS.Promise<'T> = p.``then``(id)
+    // Make sure we call `then` because this may be used with "cold" fake promises generated by Delay
+    member _.Run(p:JS.Promise<'T>): JS.Promise<'T> = p.``then``(id)
 
-    member x.Using<'T, 'R when 'T :> IDisposable>(resource: 'T, binder: 'T->JS.Promise<'R>): JS.Promise<'R> =
-        x.TryFinally(binder(resource), fun () -> resource.Dispose())
+    member this.Using<'T1, 'T2 when 'T1 :> IDisposable>(resource: 'T1, binder: 'T1 -> JS.Promise<'T2>): JS.Promise<'T2> =
+        this.TryFinally(binder(resource), fun () -> resource.Dispose())
 
     [<Emit("Promise.all([$1, $2])")>]
-    member x.MergeSources(a: JS.Promise<'T1>, b: JS.Promise<'T2>): JS.Promise<'T1 * 'T2>= jsNative
+    member _.MergeSources(a: JS.Promise<'T1>, b: JS.Promise<'T2>): JS.Promise<'T1 * 'T2> = jsNative
     
     [<Emit("Promise.all([$1, $2, $3])")>]
-    member x.MergeSources3(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>): JS.Promise<'T1 * 'T2 * 'T3>= jsNative
+    member _.MergeSources3(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>): JS.Promise<'T1 * 'T2 * 'T3> = jsNative
 
     [<Emit("Promise.all([$1, $2, $3, $4])")>]
-    member x.MergeSources4(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4>= jsNative
+    member _.MergeSources4(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4> = jsNative
     
     [<Emit("Promise.all([$1, $2, $3, $4, $5])")>]
-    member x.MergeSources5(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>, e: JS.Promise<'T5>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4 * 'T5>= jsNative
+    member _.MergeSources5(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>, e: JS.Promise<'T5>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4 * 'T5> = jsNative
     
     [<Emit("Promise.all([$1, $2, $3, $4, $5, $6])")>]
-    member x.MergeSources6(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>, e: JS.Promise<'T5>, f: JS.Promise<'T6>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4 * 'T5 * 'T6>= jsNative
+    member _.MergeSources6(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>, e: JS.Promise<'T5>, f: JS.Promise<'T6>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4 * 'T5 * 'T6> = jsNative
 
-//    member x.BindReturn(y: JS.Promise<'T1>, f) = map f y
+//    member _.BindReturn(y: JS.Promise<'T1>, f) = map f y
     
     [<Emit("Promise.all([$1,$2]).then(([a,b]) => $3(a,b))")>]
     [<CustomOperation("andFor", IsLikeZip=true)>]
-    member x.Merge(a: JS.Promise<'T1>, b: JS.Promise<'T2>, [<ProjectionParameter>] resultSelector : 'T1 -> 'T2 -> 'R): JS.Promise<'R> = jsNative
+    member _.Merge(a: JS.Promise<'T1>, b: JS.Promise<'T2>, [<ProjectionParameter>] resultSelector : 'T1 -> 'T2 -> 'R): JS.Promise<'R> = jsNative
 
     /// this is the 'base case' for Source transformations, and
     /// must be present before any user-defined overloads will


### PR DESCRIPTION
This cleans up the API for consistency and easier maintenance. There's a breaking change for `either`, see https://github.com/fable-compiler/fable-promise/pull/15#issuecomment-900746888