### PR TITLE
Hide promise-like support being a module ?

### DIFF
--- a/fable-promise.sln
+++ b/fable-promise.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Tests", "tests\Tests.fsproj", "{316D5444-688B-4177-BF18-EA4759B9D92D}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Promise", "src\Fable.Promise.fsproj", "{C7FA97C7-D598-4370-9579-765046B9828D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Debug|x64.Build.0 = Debug|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Debug|x86.Build.0 = Debug|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Release|x64.ActiveCfg = Release|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Release|x64.Build.0 = Release|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Release|x86.ActiveCfg = Release|Any CPU
+		{316D5444-688B-4177-BF18-EA4759B9D92D}.Release|x86.Build.0 = Release|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Debug|x64.Build.0 = Debug|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Debug|x86.Build.0 = Debug|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Release|x64.ActiveCfg = Release|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Release|x64.Build.0 = Release|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7FA97C7-D598-4370-9579-765046B9828D}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Promise.fs
+++ b/src/Promise.fs
@@ -151,29 +151,33 @@ type PromiseBuilder() =
 
     [<Emit("Promise.all([$1, $2])")>]
     member _.MergeSources(a: JS.Promise<'T1>, b: JS.Promise<'T2>): JS.Promise<'T1 * 'T2> = jsNative
-    
+
     [<Emit("Promise.all([$1, $2, $3])")>]
     member _.MergeSources3(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>): JS.Promise<'T1 * 'T2 * 'T3> = jsNative
 
     [<Emit("Promise.all([$1, $2, $3, $4])")>]
     member _.MergeSources4(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4> = jsNative
-    
+
     [<Emit("Promise.all([$1, $2, $3, $4, $5])")>]
     member _.MergeSources5(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>, e: JS.Promise<'T5>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4 * 'T5> = jsNative
-    
+
     [<Emit("Promise.all([$1, $2, $3, $4, $5, $6])")>]
     member _.MergeSources6(a: JS.Promise<'T1>, b: JS.Promise<'T2>, c: JS.Promise<'T3>, d: JS.Promise<'T4>, e: JS.Promise<'T5>, f: JS.Promise<'T6>): JS.Promise<'T1 * 'T2 * 'T3 * 'T4 * 'T5 * 'T6> = jsNative
 
 //    member _.BindReturn(y: JS.Promise<'T1>, f) = map f y
-    
+
     [<Emit("Promise.all([$1,$2]).then(([a,b]) => $3(a,b))")>]
     [<CustomOperation("andFor", IsLikeZip=true)>]
     member _.Merge(a: JS.Promise<'T1>, b: JS.Promise<'T2>, [<ProjectionParameter>] resultSelector : 'T1 -> 'T2 -> 'R): JS.Promise<'R> = jsNative
 
-    /// this is the 'base case' for Source transformations, and
-    /// must be present before any user-defined overloads will
-    /// actually work.
-    member x.Source(p: JS.Promise<'T1>): JS.Promise<'T1> = p
+module Extension =
 
-    // allows for..in and for..do expressions inside CEs
-    member x.Source(ps: #seq<_>): _ = ps
+    type PromiseBuilder with
+
+        /// this is the 'base case' for Source transformations, and
+        /// must be present before any user-defined overloads will
+        /// actually work.
+        member x.Source(p: JS.Promise<'T1>): JS.Promise<'T1> = p
+
+        // allows for..in and for..do expressions inside CEs
+        member x.Source(ps: #seq<_>): _ = ps

--- a/tests/Global.fs
+++ b/tests/Global.fs
@@ -1,0 +1,16 @@
+[<AutoOpen>]
+module Global
+
+open Fable.Core
+
+let inline equal (expected: 'T) (actual: 'T): unit =
+    Testing.Assert.AreEqual(expected, actual)
+
+[<Global>]
+let it (msg: string) (f: unit->JS.Promise<'T>): unit = jsNative
+
+[<Global("it")>]
+let itSync (msg: string) (f: unit->unit): unit = jsNative
+
+[<Global>]
+let describe (msg: string) (f: unit->unit): unit = jsNative

--- a/tests/PromiseLikeTests.fs
+++ b/tests/PromiseLikeTests.fs
@@ -1,0 +1,34 @@
+module PromiseLikeTests
+
+open Fable.Core
+open Promise.Extension
+
+/// this is the definition of a thenable from ts2fable's generation VsCode API
+type [<AllowNullLiteral>] Thenable<'T> =
+    abstract ``then``: ?onfulfilled: ('T -> U2<'TResult, Thenable<'TResult>>) * ?onrejected: (obj option -> U2<'TResult, Thenable<'TResult>>) -> Thenable<'TResult>
+    abstract ``then``: ?onfulfilled: ('T -> U2<'TResult, Thenable<'TResult>>) * ?onrejected: (obj option -> unit) -> Thenable<'TResult>
+
+module Thenable =
+    let toPromise (t: Thenable<'t>): JS.Promise<'t> =  unbox t
+    let ofPromise (p: JS.Promise<'t>): Thenable<'t> = unbox p
+
+type Promise.PromiseBuilder with
+    /// to make a value interop with the promise builder, you have to add an
+    /// overload of the `Source` member to convert from your type to a promise.
+    /// because thenables are trivially convertible, we can just unbox them.
+    member x.Source(t: Thenable<'t>): JS.Promise<'t> = Thenable.toPromise t
+
+
+describe "Promise like tests" <| fun _ ->
+
+    it "Promise can interop with thenables" <| fun () ->
+        let sampleThenable () =
+            promise {
+                return 1
+            }
+            |> Thenable.ofPromise
+
+        promise {
+            let! initialValue = sampleThenable()
+            initialValue |> equal 1
+        }

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -3,7 +3,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Global.fs" />
     <Compile Include="PromiseTests.fs" />
+    <Compile Include="PromiseLikeTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="3.2.3" />


### PR DESCRIPTION
As feared by @alfonsogarciacaro the released of v3 introduced some breaking changes.

One of they is that user need to write `return failwithf` instead of `return! failwithf`.

This PR is to explore an idea I had to hide the promise like support being a module. This solution seems to be working for the tests and could bring the best of both world ?

Ping @baronfel @alfonsogarciacaro 