### PR TITLE
Add AsyncIterable helpers

### DIFF
--- a/src/AsyncIterable.fs
+++ b/src/AsyncIterable.fs
@@ -1,0 +1,57 @@
+[<RequireQualifiedAccess>]
+module AsyncIterable
+
+open Fable.Core
+open Fable.Core.JsInterop
+
+[<Emit("""{
+    [Symbol.asyncIterator]() {
+        return {
+            next: $0,
+            return: $1
+        }
+    }
+}""")>]
+let private createAsyncIterator (onNext: unit -> JS.Promise<obj>) (onCancel: unit -> obj): JS.AsyncIterable<'T> = jsNative
+
+/// Creates AsyncIterable. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of#specifications
+let create (onNext: unit -> JS.Promise<'T option>): JS.AsyncIterable<'T> =
+    createAsyncIterator
+        (fun () ->
+            onNext() |> Promise.map (function
+                | Some value -> createObj ["value" ==> value; "done" ==> false]
+                | None -> createObj ["done" ==> true]
+            ))
+        (fun () -> createObj [ "done" ==> true ])
+
+/// Creates AsyncIterable with a cleaning function for cancellation (JS caller invokes `break` or `return` during iteration)
+let createCancellable (onCancel: unit -> unit) (onNext: unit -> JS.Promise<'T option>): JS.AsyncIterable<'T> =
+    createAsyncIterator
+        (fun () ->
+            onNext() |> Promise.map (function
+                | Some value -> createObj ["value" ==> value; "done" ==> false]
+                | None -> createObj ["done" ==> true]
+            ))
+        (fun () ->
+            onCancel()
+            createObj [ "done" ==> true ])
+
+type CancellationToken() =
+    member this.Cancel(): unit =
+        raise !!this
+
+/// Iterates AsyncIterable. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
+let iter (action: CancellationToken -> 'T -> unit) (iterable: JS.AsyncIterable<'T>): JS.Promise<unit> =
+    let token = CancellationToken()
+    emitJsExpr () """(async () => {
+    for await (const value of iterable) {
+        try {
+            action(token, value)
+        } catch (err) {
+            if (err instanceof token.constructor) {
+                break;
+            }
+            throw(err);
+        }
+    }
+})()"""

--- a/src/Fable.Promise.fsproj
+++ b/src/Fable.Promise.fsproj
@@ -8,12 +8,13 @@
   <ItemGroup>
     <Compile Include="Promise.fs" />
     <Compile Include="PromiseImpl.fs" />
+    <Compile Include="AsyncIterable.fs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; *.fs" PackagePath="fable\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.1.5" />
+    <PackageReference Include="Fable.Core" Version="3.7.1" />
     <PackageReference Update="FSharp.Core" Version="4.7.2" />
   </ItemGroup>
 </Project>

--- a/tests/AsyncIterable.js
+++ b/tests/AsyncIterable.js
@@ -1,0 +1,35 @@
+export async function* asyncGenerator() {
+    let i = 0;
+    while (i < 5) {
+        yield i++;
+    }
+}
+
+/**
+ * 
+ * @param {AsyncIterable<String>} iterable 
+ */
+export async function handleAsyncIterable(iterable) {
+    let acc = '';
+    for await (const value of iterable) {
+        acc = value + acc;
+    }
+    return acc;
+}
+
+/**
+ * 
+ * @param {AsyncIterable<String>} iterable 
+ */
+export async function handleAsyncIterableWithBreak(iterable) {
+    let i = 0;
+    let acc = '';
+    for await (const value of iterable) {
+        if (i === 2) {
+            break;
+        }
+        i++;
+        acc = value + acc;
+    }
+    return acc;
+}

--- a/tests/AsyncIterableTests.fs
+++ b/tests/AsyncIterableTests.fs
@@ -1,0 +1,76 @@
+module AsyncIterableTests
+
+open Fable.Core
+
+[<ImportMember("./AsyncIterable.js")>]
+let asyncGenerator(): JS.AsyncIterable<int> = jsNative
+
+[<ImportMember("./AsyncIterable.js")>]
+let handleAsyncIterable(iterable: JS.AsyncIterable<char>): JS.Promise<string> = jsNative
+
+[<ImportMember("./AsyncIterable.js")>]
+let handleAsyncIterableWithBreak(iterable: JS.AsyncIterable<char>): JS.Promise<string> = jsNative
+
+describe "AsyncIterable tests" <| fun _ ->
+
+    it "Can iterate AsyncIterable" <| fun () ->
+        let mutable acc = 0
+
+        asyncGenerator()
+        |> AsyncIterable.iter (fun _ i ->
+            acc <- acc + i)
+        |> Promise.tap (fun () ->
+            equal 10 acc)
+
+    it "Can cancel AsyncIterable" <| fun () ->
+        let mutable acc = 0
+
+        asyncGenerator()
+        |> AsyncIterable.iter (fun token i ->
+            if i = 3 then
+                token.Cancel()
+            acc <- acc + i)
+        |> Promise.tap (fun () ->
+            equal 3 acc)
+
+    it "Can error AsyncIterable" <| fun () ->
+        let mutable acc = 0
+
+        asyncGenerator()
+        |> AsyncIterable.iter (fun _ i ->
+            if i = 3 then
+                failwith "Oh, no!"
+            acc <- acc + i)
+
+        |> Promise.either
+            (fun _ -> "unexpected")
+            (fun e -> e.Message)
+
+        |> Promise.tap (equal "Oh, no!")
+
+    it "Can create AsyncIterable" <| fun () ->
+        let mutable i = -1
+        let chars = "abcd".ToCharArray()
+        AsyncIterable.create (fun () ->
+            i <- i + 1
+            Array.tryItem i chars
+            |> Promise.lift
+        )
+        |> handleAsyncIterable
+        |> Promise.tap (equal "dcba")
+
+    it "Created AsyncIterable can do cleaning on interruption" <| fun () ->
+        let mutable i = -1
+        let chars = "abcd".ToCharArray()
+        let mutable result = "dirty"
+        AsyncIterable.createCancellable
+            (fun () -> result <- "clean")
+            (fun () ->
+                i <- i + 1
+                Array.tryItem i chars
+                |> Promise.lift
+            )
+        |> handleAsyncIterableWithBreak
+        |> Promise.tap (fun value ->
+            equal "clean" result
+            equal "ba" value)

--- a/tests/PromiseTests.fs
+++ b/tests/PromiseTests.fs
@@ -365,7 +365,6 @@ describe "Promise tests" <| fun _ ->
         }
         |> Promise.tap (fun result ->
             result |> equal 3
-            ()
         )
 
     it "Promise can be run in parallel with and!" <| fun () ->

--- a/tests/Tests.fsproj
+++ b/tests/Tests.fsproj
@@ -6,9 +6,7 @@
     <Compile Include="Global.fs" />
     <Compile Include="PromiseTests.fs" />
     <Compile Include="PromiseLikeTests.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Fable.Core" Version="3.2.3" />
+    <Compile Include="AsyncIterableTests.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Fable.Promise.fsproj" />


### PR DESCRIPTION
Related to https://github.com/fable-compiler/Fable/issues/2885

@AngelMunoz @MangelMaxime Please have a look if you've a moment. More helpers can be added (e.g. create AsyncIterable from seq and fold over an AsyncIterable) but these should work for now for basic iteration.

At first I was thinking to put the helpers in the `Promise` module but at the end I added them into their own module. We can change that if it's not good for discoverability.